### PR TITLE
feat: add instagram handle to promotions

### DIFF
--- a/lib/trashy/promotions/promotion.ex
+++ b/lib/trashy/promotions/promotion.ex
@@ -8,6 +8,7 @@ defmodule Trashy.Promotions.Promotion do
     belongs_to(:cleanup, Trashy.Cleanups.Cleanup)
     field(:is_disabled, :boolean)
     field(:icon, :string)
+    field(:instagram, :string)
 
     timestamps()
   end
@@ -15,7 +16,7 @@ defmodule Trashy.Promotions.Promotion do
   @doc false
   def changeset(promotion, attrs) do
     promotion
-    |> cast(attrs, [:merchant, :details, :cleanup_id, :is_disabled, :icon])
+    |> cast(attrs, [:merchant, :details, :cleanup_id, :is_disabled, :icon, :instagram])
     |> validate_required([:merchant, :details, :cleanup_id])
   end
 end

--- a/lib/trashy_web/controllers/cleanup_html/show.html.heex
+++ b/lib/trashy_web/controllers/cleanup_html/show.html.heex
@@ -48,9 +48,10 @@
   </:actions>
 </.header>
 
-<.table id="promotions" rows={@promotions} row_click={&JS.navigate(~p"/organizer/events/#{&1}")}>
+<.table id="promotions" rows={@promotions} row_click={&JS.navigate(~p"/organizer/events/#{&1}")}> 
   <:col :let={promotion} label="Merchant"><%= promotion.merchant %></:col>
   <:col :let={promotion} label="Details"><%= promotion.details %></:col>
+  <:col :let={promotion} label="Instagram"><%= promotion.instagram %></:col>
   <:action :let={promotion}>
     <div class="sr-only">
       <.link navigate={~p"/organizer/promotions/#{promotion}"}>Show</.link>

--- a/lib/trashy_web/controllers/promotion_html/index.html.heex
+++ b/lib/trashy_web/controllers/promotion_html/index.html.heex
@@ -10,6 +10,7 @@
 <.table id="promotions" rows={@promotions} row_click={&JS.navigate(~p"/organizer/promotions/#{&1}")}>
   <:col :let={promotion} label="Merchant"><%= promotion.merchant %></:col>
   <:col :let={promotion} label="Details"><%= promotion.details %></:col>
+  <:col :let={promotion} label="Instagram"><%= promotion.instagram %></:col>
   <:col :let={promotion} label="Icon"><%= promotion.icon %></:col>
   <:col :let={promotion} label="Cleanup"><%= promotion.cleanup.neighborhood %></:col>
   <:col :let={promotion} label="Is disabled"><%= promotion.is_disabled %></:col>

--- a/lib/trashy_web/controllers/promotion_html/promotion_form.html.heex
+++ b/lib/trashy_web/controllers/promotion_html/promotion_form.html.heex
@@ -4,6 +4,7 @@
   </.error>
   <.input field={f[:merchant]} type="text" label="Merchant" />
   <.input field={f[:details]} type="text" label="Details" />
+  <.input field={f[:instagram]} type="text" label="Instagram handle" />
   <.input field={f[:icon]} type="text" label="Icon (path to asset)" />
   <.input field={f[:cleanup_id]} type="select" label="Cleanup" prompt="Select a cleanup" options={@cleanups |> Enum.map(fn c -> {c.neighborhood, c.id} end)} />
   <.input field={f[:is_disabled]} type="checkbox" label="Disabled" />

--- a/lib/trashy_web/controllers/promotion_html/show.html.heex
+++ b/lib/trashy_web/controllers/promotion_html/show.html.heex
@@ -10,6 +10,7 @@
 <.list>
   <:item title="Merchant"><%= @promotion.merchant %></:item>
   <:item title="Details"><%= @promotion.details %></:item>
+  <:item title="Instagram"><%= @promotion.instagram %></:item>
   <:item title="Icon"><%= @promotion.icon %></:item>
   <:item title="Cleanup"><%= @promotion.cleanup.neighborhood %></:item>
   <:item title="Disabled"><%= @promotion.is_disabled %></:item>

--- a/lib/trashy_web/live/certificate_live.ex
+++ b/lib/trashy_web/live/certificate_live.ex
@@ -31,6 +31,11 @@ defmodule TrashyWeb.CertificateLive do
                 <h4 class="text-xs text-white">
                   <%= promotion.promotion.details %>
                 </h4>
+                <%= if promotion.promotion.instagram do %>
+                  <h4 class="text-xs text-white">
+                    <%= promotion.promotion.instagram %>
+                  </h4>
+                <% end %>
               </div>
               <%= if promotion.is_claimed do %>
               <% else %>
@@ -60,6 +65,11 @@ defmodule TrashyWeb.CertificateLive do
                       <h4 class="text-xs text-white">
                         <%= promotion.promotion.details %>
                       </h4>
+                      <%= if promotion.promotion.instagram do %>
+                        <h4 class="text-xs text-white">
+                          <%= promotion.promotion.instagram %>
+                        </h4>
+                      <% end %>
                     </div>
                   </div>
                   <div class="flex flex-row justify-between py-6">

--- a/priv/repo/migrations/20240101000000_add_promotion_instagram.exs
+++ b/priv/repo/migrations/20240101000000_add_promotion_instagram.exs
@@ -1,0 +1,9 @@
+defmodule Trashy.Repo.Migrations.AddPromotionInstagram do
+  use Ecto.Migration
+
+  def change do
+    alter table(:promotions) do
+      add(:instagram, :string)
+    end
+  end
+end

--- a/test/support/fixtures/promotions_fixtures.ex
+++ b/test/support/fixtures/promotions_fixtures.ex
@@ -12,7 +12,8 @@ defmodule Trashy.PromotionsFixtures do
       attrs
       |> Enum.into(%{
         details: "some details",
-        merchant: "some merchant"
+        merchant: "some merchant",
+        instagram: "some instagram"
       })
       |> Trashy.Promotions.create_promotion()
 

--- a/test/trashy/promotions_test.exs
+++ b/test/trashy/promotions_test.exs
@@ -21,11 +21,12 @@ defmodule Trashy.PromotionsTest do
     end
 
     test "create_promotion/1 with valid data creates a promotion" do
-      valid_attrs = %{details: "some details", merchant: "some merchant"}
+      valid_attrs = %{details: "some details", merchant: "some merchant", instagram: "some instagram"}
 
       assert {:ok, %Promotion{} = promotion} = Promotions.create_promotion(valid_attrs)
       assert promotion.details == "some details"
       assert promotion.merchant == "some merchant"
+      assert promotion.instagram == "some instagram"
     end
 
     test "create_promotion/1 with invalid data returns error changeset" do
@@ -34,11 +35,12 @@ defmodule Trashy.PromotionsTest do
 
     test "update_promotion/2 with valid data updates the promotion" do
       promotion = promotion_fixture()
-      update_attrs = %{details: "some updated details", merchant: "some updated merchant"}
+      update_attrs = %{details: "some updated details", merchant: "some updated merchant", instagram: "some updated instagram"}
 
       assert {:ok, %Promotion{} = promotion} = Promotions.update_promotion(promotion, update_attrs)
       assert promotion.details == "some updated details"
       assert promotion.merchant == "some updated merchant"
+      assert promotion.instagram == "some updated instagram"
     end
 
     test "update_promotion/2 with invalid data returns error changeset" do

--- a/test/trashy_web/controllers/promotion_controller_test.exs
+++ b/test/trashy_web/controllers/promotion_controller_test.exs
@@ -3,8 +3,8 @@ defmodule TrashyWeb.PromotionControllerTest do
 
   import Trashy.PromotionsFixtures
 
-  @create_attrs %{details: "some details", merchant: "some merchant"}
-  @update_attrs %{details: "some updated details", merchant: "some updated merchant"}
+  @create_attrs %{details: "some details", merchant: "some merchant", instagram: "some instagram"}
+  @update_attrs %{details: "some updated details", merchant: "some updated merchant", instagram: "some updated instagram"}
   @invalid_attrs %{details: nil, merchant: nil}
 
   describe "index" do


### PR DESCRIPTION
## Summary
- allow promotions to include an optional Instagram handle
- expose Instagram handle in promotion forms and views
- show promotion handles on participant certificate

## Testing
- `mix test` *(fails: command not found: mix)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d320a3cc8321889fb9d16806fe48